### PR TITLE
Integrate AI chat and moodboard generation in frontend

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -3,11 +3,8 @@
 import 'package:flutter/material.dart';
 import 'package:photo_coach/views/chat_page.dart';
 import 'package:provider/provider.dart';
-import 'views/login_page.dart';
-import 'views/home_page.dart';
 import 'controllers/auth_controller.dart';
 import 'themes/app_theme.dart';
-import 'views/chat_page.dart';
 
 class MyApp extends StatelessWidget {
   const MyApp({super.key});
@@ -21,7 +18,6 @@ class MyApp extends StatelessWidget {
       title: 'PhotoCoach',
       debugShowCheckedModeBanner: false,
       theme: AppTheme.light(),
-      // 根據登入狀態顯示不同畫面
       home: const ChatPage(),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,7 +3,6 @@
 import 'package:flutter/material.dart';
 import 'package:provider/provider.dart';
 import 'controllers/auth_controller.dart';
-import 'state_management/providers.dart';
 import 'app.dart';
 
 void main() {

--- a/lib/models/ai_chat_response.dart
+++ b/lib/models/ai_chat_response.dart
@@ -1,0 +1,26 @@
+class AIChatResponse {
+  final String reply;
+  final List<String> subTopics;
+  final List<String> visualKeywords;
+  final String? moodboardUrl;
+  final String? itinerary;
+
+  AIChatResponse({
+    required this.reply,
+    required this.subTopics,
+    required this.visualKeywords,
+    this.moodboardUrl,
+    this.itinerary,
+  });
+
+  factory AIChatResponse.fromJson(Map<String, dynamic> json) {
+    return AIChatResponse(
+      reply: json['reply'] ?? '',
+      subTopics: List<String>.from(json['sub_topics'] ?? []),
+      visualKeywords: List<String>.from(json['visual_keywords'] ?? []),
+      moodboardUrl: json['moodboard_url'],
+      itinerary: json['itinerary'],
+    );
+  }
+}
+

--- a/lib/models/chat_message.dart
+++ b/lib/models/chat_message.dart
@@ -1,5 +1,15 @@
 class ChatMessage {
   final String text;
-  final bool fromUser; // true = 使用者, false = AI
-  ChatMessage({required this.text, required this.fromUser});
+  final bool fromUser; // true = 使用者, false = AI （誰發訊息）
+  final List<String>? subTopics;
+  final List<String>? visualKeywords;
+  final String? moodboardUrl;
+
+  ChatMessage({
+    required this.text,
+    required this.fromUser,
+    this.subTopics,
+    this.visualKeywords,
+    this.moodboardUrl,
+  });
 }

--- a/lib/services/api_service.dart
+++ b/lib/services/api_service.dart
@@ -1,0 +1,37 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../models/ai_chat_response.dart';
+
+class ApiService {
+  static const String _baseUrl = 'http://127.0.0.1:8000';
+
+  static Future<AIChatResponse> chat(String message) async {
+    final response = await http.post(
+      Uri.parse('$_baseUrl/ai/chat'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'prompt': message}),
+    );
+
+    if (response.statusCode == 200) {
+      return AIChatResponse.fromJson(jsonDecode(response.body));
+    } else {
+      throw Exception('AI 回覆失敗：${response.statusCode} ${response.body}');
+    }
+  }
+
+  static Future<String> generateMoodboard(List<String> keywords) async {
+    final response = await http.post(
+      Uri.parse('http://127.0.0.1:8000/moodboard/generate'),
+      headers: {'Content-Type': 'application/json'},
+      body: jsonEncode({'keywords': keywords}),
+    );
+
+    if (response.statusCode == 200) {
+      final json = jsonDecode(response.body);
+      return json['image_url'];
+    } else {
+      throw Exception('Moodboard 生成失敗：${response.statusCode} ${response.body}');
+    }
+  }
+
+}

--- a/lib/themes/app_theme.dart
+++ b/lib/themes/app_theme.dart
@@ -12,16 +12,15 @@ class AppTheme {
         secondary: primary,
       ),
 
-      // 全局文字樣式，讓大標題 '登入' 是深灰／黑
+      // 文字樣式
       textTheme: const TextTheme(
         headlineLarge: TextStyle(fontSize: 32, fontWeight: FontWeight.bold, color: Colors.black87),
         bodyMedium: TextStyle(color: Colors.grey),
       ),
 
-      // 輸入框邊框、浮水印、Label 都套同一個主題
       inputDecorationTheme: InputDecorationTheme(
-        filled: true,                    // 如果想要淺色背景可以打開
-        fillColor: Colors.white,         // 也可以改成 Colors.grey.shade50
+        filled: true,
+        fillColor: Colors.white,
         contentPadding: const EdgeInsets.symmetric(horizontal: 16, vertical: 14),
         labelStyle: TextStyle(color: Colors.grey.shade600),
         hintStyle: TextStyle(color: Colors.grey.shade400),
@@ -42,48 +41,47 @@ class AppTheme {
       elevatedButtonTheme: ElevatedButtonThemeData(
         style: ButtonStyle(
           // 按鈕底色
-          backgroundColor: MaterialStateProperty.all(primary),
-          // 滑鼠懸浮時改變底色透明度
-          overlayColor: MaterialStateProperty.resolveWith((states) {
-            if (states.contains(MaterialState.hovered)) {
+          backgroundColor: WidgetStateProperty.all(primary),
+          // hover 效果
+          overlayColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.hovered)) {
               return primary.withOpacity(0.1);
             }
-            // 點擊時的 splash 可以保持預設
             return null;
           }),
           // 文字顏色
-          foregroundColor: MaterialStateProperty.all(Colors.white),
+          foregroundColor: WidgetStateProperty.all(Colors.white),
           // 圓角、padding
-          shape: MaterialStateProperty.all(
+          shape: WidgetStateProperty.all(
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
-          padding: MaterialStateProperty.all(const EdgeInsets.symmetric(vertical: 16)),
+          padding: WidgetStateProperty.all(const EdgeInsets.symmetric(vertical: 16)),
         ),
       ),
 
-      // OutlinedButton：邊框灰、字色主色
+      // OutlinedButton
       outlinedButtonTheme: OutlinedButtonThemeData(
         style: ButtonStyle(
           // 預設文字+圖示色
-          foregroundColor: MaterialStateProperty.all(primary),
+          foregroundColor: WidgetStateProperty.all(primary),
           // 邊框色
-          side: MaterialStateProperty.all(const BorderSide(color: Color(0xFFEEEEEE))),
-          backgroundColor: MaterialStateProperty.all(Colors.white),
-          // hover 時把背景刷成淺灰
-          overlayColor: MaterialStateProperty.resolveWith((states) {
-            if (states.contains(MaterialState.hovered)) {
+          side: WidgetStateProperty.all(const BorderSide(color: Color(0xFFEEEEEE))),
+          backgroundColor: WidgetStateProperty.all(Colors.white),
+          // hover 效果
+          overlayColor: WidgetStateProperty.resolveWith((states) {
+            if (states.contains(WidgetState.hovered)) {
               return Colors.grey.shade100;
             }
             return null;
           }),
-          shape: MaterialStateProperty.all(
+          shape: WidgetStateProperty.all(
             RoundedRectangleBorder(borderRadius: BorderRadius.circular(8)),
           ),
-          padding: MaterialStateProperty.all(const EdgeInsets.symmetric(vertical: 16)),
+          padding: WidgetStateProperty.all(const EdgeInsets.symmetric(vertical: 16)),
         ),
       ),
 
-      // TextButton (“忘記密碼？註冊”)
+      // TextButton
       textButtonTheme: TextButtonThemeData(
         style: TextButton.styleFrom(foregroundColor: primary),
       ),

--- a/lib/views/login_page.dart
+++ b/lib/views/login_page.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 
 class LoginPage extends StatefulWidget {
-  const LoginPage({Key? key}) : super(key: key);
+  const LoginPage({super.key});
 
   @override
   _LoginPageState createState() => _LoginPageState();
@@ -22,7 +22,7 @@ class _LoginPageState extends State<LoginPage> {
           child: Column(
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
-              // Logo and title
+              // Page title
               Row(
                 children: [
                   Image.asset(
@@ -84,7 +84,7 @@ class _LoginPageState extends State<LoginPage> {
               ),
               const SizedBox(height: 8),
 
-              // Forgot password link
+              // Forgot password
               Align(
                 alignment: Alignment.centerRight,
                 child: TextButton(
@@ -108,7 +108,7 @@ class _LoginPageState extends State<LoginPage> {
               ),
               const SizedBox(height: 24),
 
-              // Or divider
+              // Divider
               Row(
                 children: const [
                   Expanded(child: Divider()),

--- a/lib/widgets/chat_bubble.dart
+++ b/lib/widgets/chat_bubble.dart
@@ -1,19 +1,25 @@
 import 'package:flutter/material.dart';
+import 'dart:convert';
 
 class ChatBubble extends StatelessWidget {
   final String text;
   final bool fromUser;
+  final List<String>? subTopics;
+  final String? moodboardUrl;
 
-  const ChatBubble({required this.text, required this.fromUser, super.key});
+  const ChatBubble({
+    required this.text,
+    required this.fromUser,
+    this.subTopics,
+    this.moodboardUrl,
+    super.key,
+  });
 
   @override
   Widget build(BuildContext context) {
     final align = fromUser ? CrossAxisAlignment.end : CrossAxisAlignment.start;
     final bgColor = fromUser
-        ? Theme
-        .of(context)
-        .colorScheme
-        .primary
+        ? Theme.of(context).colorScheme.primary
         : Colors.grey.shade100;
     final textColor = fromUser ? Colors.white : Colors.black87;
     final radius = fromUser
@@ -33,14 +39,12 @@ class ChatBubble extends StatelessWidget {
     return Column(
       crossAxisAlignment: align,
       children: [
+        // ⬛ 文字訊息泡泡
         Container(
           margin: const EdgeInsets.symmetric(vertical: 8, horizontal: 12),
           padding: const EdgeInsets.symmetric(horizontal: 14, vertical: 10),
           constraints: BoxConstraints(
-            maxWidth: MediaQuery
-                .of(context)
-                .size
-                .width * 0.7,
+            maxWidth: MediaQuery.of(context).size.width * 0.7,
           ),
           decoration: BoxDecoration(
             color: bgColor,
@@ -51,6 +55,44 @@ class ChatBubble extends StatelessWidget {
             style: TextStyle(color: textColor, fontSize: 16),
           ),
         ),
+
+        // 🟦 顯示 subTopics Chips
+        if (!fromUser && subTopics != null && subTopics!.isNotEmpty)
+          Container(
+            alignment: Alignment.centerLeft,
+            margin: const EdgeInsets.only(left: 12, right: 12, bottom: 6),
+            child: Wrap(
+              spacing: 8,
+              runSpacing: 4,
+              children: subTopics!
+                  .map((topic) => Chip(
+                label: Text(topic),
+                backgroundColor: Colors.teal.shade50,
+                shape: RoundedRectangleBorder(
+                  borderRadius: BorderRadius.circular(20),
+                ),
+              ))
+                  .toList(),
+            ),
+          ),
+
+        if (!fromUser && moodboardUrl != null)
+          Container(
+            margin: const EdgeInsets.symmetric(horizontal: 12),
+            child: ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: moodboardUrl!.startsWith('data:image')
+                  ? Image.memory(
+                // decode base64 string (移除前綴)
+                base64Decode(moodboardUrl!.split(',').last),
+                width: MediaQuery.of(context).size.width * 0.7,
+              )
+                  : Image.network(
+                moodboardUrl!,
+                width: MediaQuery.of(context).size.width * 0.7,
+              ),
+            ),
+          ),
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -75,6 +75,22 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  http:
+    dependency: "direct main"
+    description:
+      name: http
+      sha256: "2c11f3f94c687ee9bad77c171151672986360b2b001d109814ee7140b2cf261b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
   leak_tracker:
     dependency: transitive
     description:
@@ -208,6 +224,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.4"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
   vector_math:
     dependency: transitive
     description:
@@ -224,6 +248,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.0.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.8.1 <4.0.0"
   flutter: ">=3.18.0-18.0.pre.54"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,6 +35,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
   provider: ^6.1.0
+  http: ^1.4.0
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## 實作功能

- 前端整合 AI 對話與 Moodboard 產生功能
- 使用者輸入主題後，會：
  1. 呼叫 AI API 回傳子主題與視覺風格關鍵字
  2. 將視覺關鍵字送出產生 moodboard 並回傳圖像
  3. 在 chat bubble 中顯示子主題 chips 及 moodboard 圖片

## 調整部分

- `lib/views/chat_page.dart`：新增串接流程與 UI 顯示邏輯
- `lib/widgets/chat_bubble.dart`：支援圖片顯示與 subtopics chips
- `lib/services/api_service.dart`：新增 `generateMoodboard()` 方法
- `lib/models/ai_chat_response.dart`：新增 AI 回傳資料模型
- 其他：樣式微調（`app_theme.dart`）、路由設定（`app.dart`、`main.dart`）
